### PR TITLE
Added strategy "Swing-High-To-Sky"

### DIFF
--- a/user_data/strategies/Swing-High-To-Sky.py
+++ b/user_data/strategies/Swing-High-To-Sky.py
@@ -1,0 +1,71 @@
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from typing import Dict, List
+from functools import reduce
+from pandas import DataFrame
+# --------------------------------
+
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+import numpy # noqa
+
+__author__      = "Kevin Ossenbrück"
+__copyright__   = "Free For Use"
+__credits__     = ["Bloom Trading, Mohsen Hassan"]
+__license__     = "MIT"
+__version__     = "1.0"
+__maintainer__  = "Kevin Ossenbrück"
+__email__       = "kevin.ossenbrueck@pm.de"
+__status__      = "Live"
+
+class_name = 'SwingHighToSky'
+class SwingHighToSky(IStrategy):
+
+    # Disable ROI
+    minimal_roi = {
+         "0":  100
+    }
+
+    stoploss = -0.30
+    trailing_stop = True
+    trailing_stop_positive = 0.08
+    trailing_stop_positive_offset = 0.10
+    trailing_only_offset_is_reached = True
+
+    ticker_interval = '30m'
+
+    def informative_pairs(self):
+        return []
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        
+        macd = ta.MACD(dataframe)
+        dataframe['macd'] = macd['macd']
+        dataframe['macdsignal'] = macd['macdsignal']
+        dataframe['macdhist'] = macd['macdhist']
+        
+        dataframe['cci'] = ta.CCI(dataframe)
+
+        return dataframe
+
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        
+        dataframe.loc[
+            (
+                (dataframe['macd'] > dataframe['macdsignal']) &
+                (dataframe['cci'] <= -100.0)
+            ),
+            'buy'] = 1
+
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        
+        dataframe.loc[
+            ( 
+                (dataframe['macd'] < dataframe['macdsignal']) & 
+                (dataframe['cci'] >= 200.0)
+            ),
+            'sell'] = 1
+            
+        return dataframe


### PR DESCRIPTION
## Hello dear community,

I like to share my newest hyperopt with you. I though about how cool it would be to know what's the perfect timeperiod for CCI indicator. In a strategy you do something like this: `dataframe['cci'] = ta.CCI(timeperiod=14)`

You would do this by hand for each timeperiod which is very annoying. Therefore, I created this hyperopt to looking for the perfect timeperiod for the CCI indicator. Please review this pull request very critical and share your minds.

Since the last two months (from 1st Jan 2021 until now) this strategy in BTC/USDT 30m chart had worked **very very** well. After two months I now optimize this strategy again.

## Summary
The goal of this hyper-optimization is to find the perfect timeframe of the CCI indicator (from 10 to 100) within a range from -400 to +400. The MACD indicator here is just a favorite of myself, replace with your favorit indicator if you like.